### PR TITLE
added torbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The script accepts the following arguments:
 - `--repair-interval`: Optional interval in smart format (e.g., '1h2m3s') to wait between repairing each media file.
 - `--run-interval`: Optional interval in smart format (e.g., '1w2d3h4m5s') to run the repair process.
 - `--mode`: Choose repair mode: `symlink` or `file`. `symlink` to repair broken symlinks and `file` to repair missing files. (default: 'symlink').
+- `--season-packs`: Upgrade to season-packs when a non-season-pack is found. Only applicable in symlink mode.
 - `--include-unmonitored`: Include unmonitored media in the repair process.
 
 ### Warning

--- a/blackhole.py
+++ b/blackhole.py
@@ -357,14 +357,14 @@ async def fail(torrent: TorrentBase, arr: Arr, isRadarr):
         isSeasonPack = firstItem.releaseType == 'SeasonPack'
         
         # For season packs, we only need to fail one episode and trigger one search
-        items = [firstItem] if not isRadarr and isSeasonPack else items
+        items = [firstItem] if isSeasonPack else items
 
         # Mark items as failed
         failTasks = [asyncio.to_thread(arr.failHistoryItem, item.id) for item in items]
         await asyncio.gather(*failTasks)
 
-        # For season packs in Sonarr, trigger a new search
-        if not isRadarr and isSeasonPack:
+        # For season packs, trigger a new search
+        if isSeasonPack:
             for item in items:
                 series = await asyncio.to_thread(arr.get, item.grandparentId)
                 await asyncio.to_thread(arr.automaticSearch, series, item.parentId)

--- a/blackhole.py
+++ b/blackhole.py
@@ -345,7 +345,7 @@ async def fail(torrent: TorrentBase, arr: Arr, isRadarr):
     print(f"Failing")
     
     torrentHash = torrent.getHash()
-    history = await asyncio.to_thread(arr.getHistory, blackhole['historyPageSize'])
+    history = await asyncio.to_thread(arr.getHistory, blackhole['historyPageSize'], includeGrandchildDetails=True)
     items = [item for item in history if (item.torrentInfoHash and item.torrentInfoHash.casefold() == torrentHash.casefold()) or cleanFileName(item.sourceTitle.casefold()) == torrent.file.fileInfo.filenameWithoutExt.casefold()]
     
     if not items:

--- a/import_torrent_folder.py
+++ b/import_torrent_folder.py
@@ -1,21 +1,44 @@
 import os
 import re
+import time
 import argparse
-from shared.shared import blackhole, realdebrid
+from shared.shared import blackhole, realdebrid, torbox
 
-parentDirectory = realdebrid['mountTorrentsPath']
-
-def get_completed_parent_directory(args):
-    if args.symlink_directory:
-        return args.symlink_directory
-    elif args.radarr:
+def get_completed_parent_directory(use_radarr, use_radarr4k, use_radarranime, use_radarrmux, use_sonarr, use_sonarr4k, use_sonarranime, use_sonarrmux, custom_directory):
+    if custom_directory:
+        return custom_directory
+    elif use_radarr:
         return f"{blackhole['baseWatchPath']}/{blackhole['radarrPath']}/completed"
-    elif args.sonarr:
+    elif use_radarr4k:
+        return f"{blackhole['baseWatchPath']}/{blackhole['radarr4kPath']} 4k/completed"
+    elif use_radarranime:
+        return f"{blackhole['baseWatchPath']}/{blackhole['radarranimePath']} anime/completed"
+    elif use_radarrmux:
+        return f"{blackhole['baseWatchPath']}/{blackhole['radarrPath']} mux/completed"
+    elif use_sonarr:
         return f"{blackhole['baseWatchPath']}/{blackhole['sonarrPath']}/completed"
+    elif use_sonarr4k:
+        return f"{blackhole['baseWatchPath']}/{blackhole['sonarrPath']} 4k/completed"
+    elif use_sonarranime:
+        return f"{blackhole['baseWatchPath']}/{blackhole['sonarrPath']} anime/completed" 
+    elif use_sonarrmux:
+        return f"{blackhole['baseWatchPath']}/{blackhole['sonarrPath']} mux/completed" # docker-compose.yml adds a space between path and instance title
     else:
-        return
+        return None
 
-def process_directory(directory, completedParentDirectory, custom_regex=None, dry_run=False):
+def retry_find_directory(directory, max_retries=60, wait_time=1):
+    """Retry finding the directory every second for a total of 60 seconds, updating the status message."""
+    print("Finding torrents", end="", flush=True)
+    for attempt in range(max_retries):
+        if os.path.isdir(directory):
+            print("\nDirectory found.")
+            return True
+        print(".", end="", flush=True)
+        time.sleep(wait_time)
+    print("\nFailed to find directory.")
+    return False
+
+def process_directory(directory, completedParentDirectory, custom_regex=None, dry_run=False, parentDirectory=None):
     fullDirectory = os.path.join(parentDirectory, directory)
     completedFullDirectory = os.path.join(completedParentDirectory, directory)
 
@@ -26,6 +49,12 @@ def process_directory(directory, completedParentDirectory, custom_regex=None, dr
         multiSeasonRegexCombined += f'|{custom_regex}'
 
     multiSeasonMatch = re.search(multiSeasonRegexCombined, directory)
+
+    if not retry_find_directory(fullDirectory):
+        print(f"Failed to find directory: {fullDirectory} after 60 seconds.")
+        return
+    # Print the message indicating the directory being processed
+    print(f"Symlinks sent to {completedParentDirectory.split('/')[-2]} for {directory}")
 
     for root, dirs, files in os.walk(fullDirectory):
         relRoot = os.path.relpath(root, fullDirectory)
@@ -47,18 +76,22 @@ def process_directory(directory, completedParentDirectory, custom_regex=None, dr
                     if not dry_run:
                         os.makedirs(os.path.join(completedSeasonFullDirectory, relRoot), exist_ok=True)
                         os.symlink(os.path.join(root, filename), os.path.join(completedSeasonFullDirectory, relRoot, filename))
-                    print('Season Recursive:', f"{os.path.join(completedSeasonFullDirectory, relRoot, filename)} -> {os.path.join(root, filename)}")
-
                     continue
 
             if not dry_run:
                 os.makedirs(os.path.join(completedFullDirectory, relRoot), exist_ok=True)
                 os.symlink(os.path.join(root, filename), os.path.join(completedFullDirectory, relRoot, filename))
-            print('Recursive:', f"{os.path.join(completedFullDirectory, relRoot, filename)} -> {os.path.join(root, filename)}")
 
-def process(directory, completedParentDirectory, custom_regex, dry_run=False, no_confirm=False):
+def process(directory, service, completedParentDirectory, custom_regex, dry_run=False, no_confirm=False, parentDirectory=None):
+    if service == 'rd':
+        parentDirectory = realdebrid['mountTorrentsPath']
+    elif service == 'tb':
+        parentDirectory = torbox['mounttorrentsPath']
+    else:
+        raise ValueError("Invalid service. Must be 'rd' or 'tb'.")
+
     if directory:
-        process_directory(directory, completedParentDirectory, custom_regex, dry_run)
+        process_directory(directory, completedParentDirectory, custom_regex, dry_run, parentDirectory=parentDirectory)
     else:
         for directory in os.listdir(parentDirectory):
             fullDirectory = os.path.join(parentDirectory, directory)
@@ -69,24 +102,97 @@ def process(directory, completedParentDirectory, custom_regex, dry_run=False, no
                     print(f"Processing {directory}...")
                 response = input("Do you want to process this directory? (y/n): ") if not no_confirm and not dry_run else 'y'
                 if response.lower() == 'y':
-                    process_directory(directory, completedParentDirectory, custom_regex, dry_run)
+                    process_directory(directory, completedParentDirectory, custom_regex, dry_run, parentDirectory=parentDirectory)
                 else:
                     print(f"Skipping processing of {directory}")
 
-if __name__ == '__main__':
+
+def main():
     parser = argparse.ArgumentParser(description='Process directories for torrent imports.')
     parser.add_argument('--directory', type=str, help='Specific directory to process')
+    parser.add_argument('--realdebrid', action='store_true', help='Select RealDebrid mount')
+    parser.add_argument('--torbox', action='store_true', help='Select Torbox mount')
     parser.add_argument('--custom-regex', type=str, help='Custom multi-season regex')
     parser.add_argument('--dry-run', action='store_true', help='Print actions without executing')
     parser.add_argument('--no-confirm', action='store_true', help='Execute without confirmation')
     parser.add_argument('--radarr', action='store_true', help='Use the Radarr symlink directory')
+    parser.add_argument('--radarr4k', action='store_true', help='Use the Radarr4K symlink directory')
+    parser.add_argument('--radarranime', action='store_true', help='Use the RadarrAnime symlink directory')
+    parser.add_argument('--radarrmux', action='store_true', help='Use the Radarrmux symlink directory')
     parser.add_argument('--sonarr', action='store_true', help='Use the Sonarr symlink directory')
+    parser.add_argument('--sonarr4k', action='store_true', help='Use the Sonarr4K symlink directory')
+    parser.add_argument('--sonarranime', action='store_true', help='Use the SonarrAnime symlink directory')
+    parser.add_argument('--sonarrmux', action='store_true', help='Use the Sonarrmux symlink directory')
     parser.add_argument('--symlink-directory', type=str, help='Custom symlink directory')
     args = parser.parse_args()
 
-    completedParentDirectory = get_completed_parent_directory(args)
-    if not completedParentDirectory:
-        parser.error("One of --radarr, --sonarr, or --symlink-directory is required.")
+    # Determine the service from the command line arguments
+    service = None
+    if args.realdebrid:
+        service = 'rd'
+    elif args.torbox:
+        service = 'tb'
 
-    process(args.directory, completedParentDirectory, args.custom_regex, args.dry_run, args.no_confirm)
+    if args.directory or args.radarr or args.radarr4k or args.radarranime or args.radarrmux or args.sonarr or args.sonarr4k or args.sonarranime or args.sonarrmux or args.symlink_directory:
+        # Process once with the provided arguments and exit
+        completedParentDirectory = get_completed_parent_directory(
+            args.radarr, args.radarr4k, args.radarranime, args.radarrmux,
+            args.sonarr, args.sonarr4k, args.sonarranime, args.sonarrmux,
+            args.symlink_directory
+        )
+        if not completedParentDirectory:
+            parser.error("One of --radarr, --radarr4k, --radarranime, --sonarr, --sonarr4k, --sonarranime, or --symlink-directory is required.")
+        
+        if service is None:
+            raise ValueError("Either --realdebrid or --torbox must be specified.")
+        
+        process(args.directory, service, completedParentDirectory, args.custom_regex, args.dry_run, args.no_confirm)
+    else:
+        # Enter interactive loop for continuous processing
+        while True:
+            directory = input("Enter the torrent folder name to process: ").strip('"').strip("'") # remove any quotes to prevent issues if users paste linux folder names with spaces in them
 
+            # If service was not provided through arguments, prompt the user
+            if service is None:
+                service = input("Is this RealDebrid or Torbox? (rd/tb)").strip().lower()
+                if service not in ['rd', 'tb']:
+                    print("Invalid service. Please enter either 'rd' for RealDebrid or 'tb' for Torbox.")
+                    continue
+            
+            choice = input("Is this for Radarr, Radarr4K, RadarrAnime, Radarrmux, Sonarr, Sonarr4K, SonarrAnime, or Sonarrmux? (r/r4k/ra/rm/s/s4k/sa/sm): ").strip().lower()
+            
+            radarr, radarr4k, radarranime, radarrmux, sonarr, sonarr4k, sonarranime, sonarrmux = False, False, False, False, False, False, False, False
+            
+            if choice == 'r':
+                radarr = True
+            elif choice == 'r4k':
+                radarr4k = True
+            elif choice == 'ra':
+                radarranime = True
+            elif choice == 'rm':
+                radarrmux = True
+            elif choice == 's':
+                sonarr = True
+            elif choice == 's4k':
+                sonarr4k = True
+            elif choice == 'sa':
+                sonarranime = True
+            elif choice == 'sm':
+                sonarrmux == True
+            else:
+                print("Invalid choice. Please try again.")
+                continue
+
+            completedParentDirectory = get_completed_parent_directory(
+                radarr, radarr4k, radarranime, radarrmux,
+                sonarr, sonarr4k, sonarranime, sonarrmux,
+                None
+            )
+            if not completedParentDirectory:
+                print("Invalid directory configuration. Please try again.")
+                continue
+
+            process(directory, service, completedParentDirectory, args.custom_regex, args.dry_run, args.no_confirm)
+
+if __name__ == '__main__':
+    main()

--- a/repair.py
+++ b/repair.py
@@ -30,7 +30,6 @@ parser.add_argument('--repair-interval', type=str, default=repair['repairInterva
 parser.add_argument('--run-interval', type=str, default=repair['runInterval'], help='Optional interval in smart format (e.g. 1w2d3h4m5s) to run the repair process.')
 parser.add_argument('--mode', type=str, choices=['symlink', 'file'], default='symlink', help='Choose repair mode: `symlink` or `file`. `symlink` to repair broken symlinks and `file` to repair missing files.')
 parser.add_argument('--season-packs', action='store_true', help='Upgrade to season-packs when a non-season-pack is found. Only applicable in symlink mode.')
-parser.add_argument('--soft-repair', action='store_true', help='Only search for missing files, do not delete or re-grab. This is always enabled in file mode.')
 parser.add_argument('--include-unmonitored', action='store_true', help='Include unmonitored media in the repair process')
 args = parser.parse_args()
 
@@ -104,7 +103,7 @@ def main():
                     if args.dry_run or args.no_confirm or input("Do you want to delete and re-grab? (y/n): ").lower() == 'y':
                         if not args.dry_run:
                             discordUpdate(f"[{args.mode}] Repairing {media.title}: {childId}")
-                            if args.mode == 'symlink' and not args.soft_repair:
+                            if args.mode == 'symlink':
                                 print("Deleting files:")
                                 [print(item.path) for item in childItems]
                                 results = arr.deleteFiles(childItems)

--- a/shared/arr.py
+++ b/shared/arr.py
@@ -254,6 +254,7 @@ class EpisodeHistory(MediaHistory):
         return self.json['episode']['seasonNumber']
 
     @property
+    # Requires includeGrandchildDetails to be true
     def grandparentId(self):
         """Get the series ID from the history item."""
         return self.json['episode']['seriesId']

--- a/shared/arr.py
+++ b/shared/arr.py
@@ -213,6 +213,11 @@ class MediaHistory(ABC):
         return self.json['data'].get('torrentInfoHash')
 
     @property
+    def releaseType(self):
+        """Get the release type from the history item data."""
+        return self.json['data'].get('releaseType')
+
+    @property
     @abstractmethod
     def parentId(self):
         pass

--- a/shared/arr.py
+++ b/shared/arr.py
@@ -219,6 +219,12 @@ class MediaHistory(ABC):
 
     @property
     @abstractmethod
+    def grandparentId(self):
+        """Get the top-level ID (series ID for episodes, same as parentId for movies)."""
+        pass
+
+    @property
+    @abstractmethod
     def isFileDeletedEvent(self):
         pass
 
@@ -226,6 +232,11 @@ class MovieHistory(MediaHistory):
     @property
     def parentId(self):
         return self.json['movieId']
+
+    @property
+    def grandparentId(self):
+        """For movies, grandparent ID is the same as parent ID."""
+        return self.parentId
 
     @property
     def isFileDeletedEvent(self):
@@ -236,6 +247,11 @@ class EpisodeHistory(MediaHistory):
     # Requires includeGrandchildDetails to be true
     def parentId(self):
         return self.json['episode']['seasonNumber']
+
+    @property
+    def grandparentId(self):
+        """Get the series ID from the history item."""
+        return self.json['episode']['seriesId']
 
     @property
     def isFileDeletedEvent(self):

--- a/shared/debrid.py
+++ b/shared/debrid.py
@@ -439,7 +439,7 @@ class Torbox(TorrentBase):
         return not not deleteRequest
 
     async def getTorrentPath(self):
-        filename = (await self.getInfo())['name']
+        filename = (await self.getInfo())['files'][0]['name'].split("/")[0]
 
         folderPathMountFilenameTorrent = os.path.join(self.mountTorrentsPath, filename)
        
@@ -486,7 +486,7 @@ class Torbox(TorrentBase):
             'queuedDL', 'checkingDL', 'forcedDL', 'checkingResumeData', 'moving'
         ]:
             return self.STATUS_DOWNLOADING
-        elif status in ['error', 'stalledUP', 'stalledDL', 'stalled (no seeds)', 'missingFiles']:
+        elif status in ['error', 'stalledUP', 'stalledDL', 'stalled (no seeds)', 'missingFiles', 'failed']:
             return self.STATUS_ERROR
         return status
 


### PR DESCRIPTION
- added realdebrid and torbox args (use `--realdebrid` or `--torbox`) 
- added `service` variable for user input for `rd` or `tb` during interactive
- adjusted *arr paths to include a space (the example docker-compose.yml file has spaces between `BASE_SONARR_PATH` and `anime` 
- added trim to deal with users entering quotes in the directory name for folders with spaces which was causing false failures
